### PR TITLE
CI: enable uploading api-examples docs to S3 bucket

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,6 +39,7 @@ jobs:
       MATERIALS_PROJECT_API_KEY: ${{ secrets.MATERIALS_PROJECT_API_KEY }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCS_MAT3RA_COM_CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.DOCS_MAT3RA_COM_CLOUDFRONT_DISTRIBUTION_ID }}
     defaults:
       run:
         shell: bash -l {0}
@@ -100,7 +101,7 @@ jobs:
           folder: site
           bucket: docs.mat3ra.com/rest-api/api-examples/rendered-notebooks
           bucket-region: us-west-2
-          dist-id: ${{ secrets.DOCS_MAT3RA_COM_CLOUDFRONT_DISTRIBUTION_ID }}
+          dist-id: ${{ env.DOCS_MAT3RA_COM_CLOUDFRONT_DISTRIBUTION_ID }}
           invalidation: /*
           no-cache: true
           private: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -98,7 +98,7 @@ jobs:
         uses: Exabyte-io/action-s3-deploy@v3
         with:
           folder: site
-          bucket: docs.mat3ra.com/rest-api/api-examples
+          bucket: docs.mat3ra.com/rest-api/api-examples/rendered-notebooks
           bucket-region: ${{ secrets.S3_LOCATION }}
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
           invalidation: /*

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,6 +37,8 @@ jobs:
       ACCOUNT_ID: ${{ secrets.DEMO_ACCOUNT_ID }}
       AUTH_TOKEN: ${{ secrets.DEMO_AUTH_TOKEN }}
       MATERIALS_PROJECT_API_KEY: ${{ secrets.MATERIALS_PROJECT_API_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
     defaults:
       run:
         shell: bash -l {0}
@@ -90,3 +92,15 @@ jobs:
           destination_dir: ./docs
           keep_files: true  # Keep old files.
           force_orphan: false  # Keep git history.
+
+      - name: S3 Deploy
+        if: github.repository_owner == 'Exabyte-io' && github.ref_name == 'dev' && matrix.python-version == '3.8'
+        uses: Exabyte-io/action-s3-deploy@v3
+        with:
+          folder: site
+          bucket: docs.mat3ra.com/rest-api/api-examples
+          bucket-region: ${{ secrets.S3_LOCATION }}
+          dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          invalidation: /*
+          no-cache: true
+          private: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,8 +37,8 @@ jobs:
       ACCOUNT_ID: ${{ secrets.DEMO_ACCOUNT_ID }}
       AUTH_TOKEN: ${{ secrets.DEMO_AUTH_TOKEN }}
       MATERIALS_PROJECT_API_KEY: ${{ secrets.MATERIALS_PROJECT_API_KEY }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -99,8 +99,8 @@ jobs:
         with:
           folder: site
           bucket: docs.mat3ra.com/rest-api/api-examples/rendered-notebooks
-          bucket-region: ${{ secrets.S3_LOCATION }}
-          dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          bucket-region: us-west-2
+          dist-id: ${{ secrets.DOCS_MAT3RA_COM_CLOUDFRONT_DISTRIBUTION_ID }}
           invalidation: /*
           no-cache: true
           private: true

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Follow the steps below in order to setup and view the Jupyter notebooks:
     ```
 
     Or, if you have set up SSH keys
-    
+
     ```bash
     git clone git@github.com:Exabyte-io/api-examples.git
     ```


### PR DESCRIPTION
Uses an example from https://github.com/Exabyte-io/documentation/blob/master/.github/workflows/update.yml.